### PR TITLE
Add Stremio discord addon

### DIFF
--- a/src/addonsList.json
+++ b/src/addonsList.json
@@ -245,6 +245,13 @@
 		"repo": "Sleeyax/stremio-local-rarbg-torrents-4k"
 	},
 	{
+		"name": "Discord Rich Presence",
+		"logo": "https://i.imgur.com/HGIkQgD.png",
+		"description": "Show the movie or series you're watching in Discord",
+		"types": ["Movies", "Series"],
+		"repo": "Sleeyax/stremio-discord"
+	},
+	{
 		"name": "Fluxus Cinema",
 		"logo": "https://3.bp.blogspot.com/-H29TnFg5qi8/XJRl9LkCOPI/AAAAAAAAERM/NMz9wJR8iksFemvDu1kGWb9soX41HopxgCLcBGAs/s1600/NewFTV-IPTV-C.png",
 		"description": "Movies from Fluxus Cinema. Includes: English, German, French, Italian, Spanish, Portuguese, Japanese and Arabic movies.",

--- a/src/addonsList.json
+++ b/src/addonsList.json
@@ -249,7 +249,8 @@
 		"logo": "https://i.imgur.com/HGIkQgD.png",
 		"description": "Show the movie or series you're watching in Discord",
 		"types": ["Movies", "Series"],
-		"repo": "Sleeyax/stremio-discord"
+		"repo": "Sleeyax/stremio-discord",
+		"requires": "1.1.9"
 	},
 	{
 		"name": "Fluxus Cinema",

--- a/src/lib/vm.js
+++ b/src/lib/vm.js
@@ -30,7 +30,7 @@ const vmApi = {
 		'lodash', 'google-it', 'cheerio', 'jsdom', 'xml2js', 'cache-manager', 'bottleneck',
 		'magnet-uri', 'torrent-name-parser', 'request', 'cheerio-without-node-native',
 		'cross-fetch', 'cloudscraper', 'axios', 'remote-file-size', 'base-64', 'compare-versions',
-		'js-events-listener', 'qs', 'string_decoder', 'm3u8-parsed'
+		'js-events-listener', 'qs', 'string_decoder', 'm3u8-parsed', 'discord-rpc'
 	],
 	excluded: ['stremio-addon-sdk', 'internal', 'phantom', 'eval', 'dom-storage'],
 	allModules: () => {

--- a/src/package.json
+++ b/src/package.json
@@ -21,6 +21,7 @@
     "cross-fetch": "^2.1.0",
     "crypto-js": "3.1.9-1",
     "death": "^1.1.0",
+    "discord-rpc": "^3.1.0",
     "encoding": "^0.1.12",
     "ent": "^2.2.0",
     "express": "^4.16.4",


### PR DESCRIPTION
This addon will display the current movie or series as 'game activity' on Discord. It requires the [discord-rpc](https://www.npmjs.com/package/discord-rpc) package to be whitelisted though.