### PR TITLE
Fix and document proxy noFollowSegment

### DIFF
--- a/docs/modules-internal.md
+++ b/docs/modules-internal.md
@@ -56,7 +56,8 @@ Supported proxy options:
     "encodeUtf8": true, // default: false, encodes the subtitle to UTF8
     "encoding": "ISO-8859-7" // default: false, set currect encoding manually, if this is not set it will be guessed
   },
-  "playlist": true // default: false, if segments of hls are from a separate domain then the playlist, this proxifies the segment URLs too
+  "playlist": true, // default: false, if segments of hls are from a separate domain then the playlist, this proxifies the segment URLs too, it also proxifies any hls key url too where applicable
+  "noFollowSegment": false // default: false, when setting the playlist property to true the default behavior is to proxify all segments also, but there is a case where you might want to proxify only the hls key url, setting this property to true allows that
 }
 ```
 

--- a/src/lib/proxy.js
+++ b/src/lib/proxy.js
@@ -141,9 +141,9 @@ const proxify = {
 								body.split(/\r?\n/).forEach(line => {
 									if (line.startsWith('http://') || line.startsWith('https://')) {
 										if (newOpts.noFollowSegment)
-											newPlaylist.push(proxify.addProxy(line, newOpts))
-										else
 											newPlaylist.push(line)
+										else
+											newPlaylist.push(proxify.addProxy(line, newOpts))
 									} else if (line.match(/URI="([^"]+)/)) {
 										const nUrl = line.match(/URI="([^"]+)/)
 										let oldUrl


### PR DESCRIPTION
There was a setting called `noFollowSegment` that was undocumented and breaking an addon.

It seems that this was made to state that you wish to not proxy segment files if `playlist` was set to `true`. But in reality, the logic stated that it was doing the exact opposite of what it was supposed to, thus not following segments at all when setting `playlist` to `true` unless also setting `noFollowSegment` to `true`.

This fixes the logic, and also documents this property.

Thanks so much for building this thing, it's really amazing to work with it. :)