### PR TITLE
Add linux alpine as build target

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -181,7 +181,7 @@ function packageApp() {
 
 	console.log('Start - Packaging App to Executable')
 
-	exec(['package.json', '--target', 'host', '--output', '../assets/engine' + ext()]).then(() => {
+	exec(['package.json', '--target', 'host,alpine', '--output', '../assets/engine' + ext()]).then(() => {
 
 		console.log('Finished!')
 


### PR DESCRIPTION
[pkg](https://www.npmjs.com/package/pkg) supports `alpine` as one of the many build targets. We should add this to the build script and also publish to github releases if we want want to support alpine-based docker images for PMS.