### PR TITLE
Add docker support (closes #82)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM frolvlad/alpine-glibc
+
+LABEL description="Local add-on manager for Stremio"
+
+ARG version=1.2.2
+ARG port=7777
+
+WORKDIR /app
+
+RUN apk add --update --no-cache unzip wget libstdc++
+RUN wget -O pms.zip https://github.com/sungshon/PimpMyStremio/releases/download/v${version}/PimpMyStremio-linux.zip
+RUN unzip -j pms.zip
+RUN chmod +x ./PimpMyStremio
+
+VOLUME ["/root/.local/share/PimpMyStremio/"]
+VOLUME ["/app/sideloaded"]
+
+EXPOSE ${port}
+
+ENTRYPOINT ["/app/PimpMyStremio", "--sideload=", "/app/sideloaded", "--verbose"]


### PR DESCRIPTION
Not sure where and how you want to update the docs so here's a snippet from my [README](https://github.com/sleeyax/pimpmystremio-docker):

## Usage
`docker run -v <data path>:/root/.local/share/PimpMyStremio/ <sideloaded addons path>:/app/sideloaded -p [<host ip>:]<host port>:7777 --build-arg version=<PMS version to use> sleeyax/pimpmystremio`

### Examples

Quick start:

`docker run -p 7777:7777 sleeyax/pimpmystremio`

Advanced:

`docker run -v ~/Documents/PimpMyStremio/data:/root/.local/share/PimpMyStremio/ ~/Documents/PimpMyStremio/sideloaded:/app/sideloaded -p 127.0.0.1:7777:7777 --build-arg version=1.2.2 sleeyax/pimpmystremio`

After running any of the commands above, PMS should should be available at http://localhost:7777 .

----

On a sidenote I don't think PMS supports specifying a different port yet, but this Dockerfile assumes it does (to be ready for the future). Though you'll only have to change ` ENTRYPOINT ["/app/PimpMyStremio", "--sideload=", "/app/sideloaded", "--verbose"] ` to `ENTRYPOINT /app/PimpMyStremio --sideload= /app/sideloaded --port ${port} --verbose` or something alike.